### PR TITLE
Switch ingestion to Sports Game Odds API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# Bet-Exchange-Bot-
-This is a seamless bot designed to profit from arb opportunities 
+# Bet Exchange Bot
+
+This repository contains a skeleton implementation of a sports betting arbitrage and analytics system.
+It ingests odds from multiple sources, searches for arbitrage and value bets, applies bankroll and
+stake sizing logic, and can automate bet placement.
+It uses the free Sports Game Odds API to retrieve live odds data.
+
+The code is intentionally minimal and focuses on the structure outlined in the architecture plan.
+All modules include basic functions and placeholder implementations so the project can be developed
+further.
+
+## Structure
+- `bet_exchange_bot/ingestion.py` - fetches odds data from the Sports Game Odds API.
+- `bet_exchange_bot/normalization.py` – converts odds formats and matches events.
+- `bet_exchange_bot/arbitrage.py` – scans for arbitrage opportunities.
+- `bet_exchange_bot/predictive.py` – contains simple predictive model stubs.
+- `bet_exchange_bot/staking.py` – bankroll and stake calculations using Kelly criterion.
+- `bet_exchange_bot/execution.py` – hooks for automating bet placement.
+- `bet_exchange_bot/alerts.py` – basic Telegram alert sender.
+- `bet_exchange_bot/server.py` – FastAPI application orchestrating the workflow.
+
+## Requirements
+- Python 3.10+
+- `aiohttp`, `pydantic`, `fastapi`, `uvicorn`
+
+Install dependencies with:
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+The project currently only provides a basic FastAPI application. It fetches odds from the Sports Game Odds API to demonstrate free data ingestion. Run it with:
+```bash
+uvicorn bet_exchange_bot.server:app --reload
+```

--- a/bet_exchange_bot/alerts.py
+++ b/bet_exchange_bot/alerts.py
@@ -1,0 +1,19 @@
+import asyncio
+from typing import Optional
+
+import aiohttp
+
+
+class TelegramAlerter:
+    def __init__(self, bot_token: str, chat_id: str) -> None:
+        self.bot_token = bot_token
+        self.chat_id = chat_id
+
+    async def send(self, message: str) -> None:
+        url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
+        payload = {"chat_id": self.chat_id, "text": message}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    print("Failed to send alert", text)

--- a/bet_exchange_bot/arbitrage.py
+++ b/bet_exchange_bot/arbitrage.py
@@ -1,0 +1,47 @@
+from collections import defaultdict
+from typing import List, Dict, Any, Optional
+
+
+def find_two_way_arbitrage(odds: List[Dict[str, Any]], threshold: float = 1.0) -> Optional[Dict[str, Any]]:
+    """Return an arbitrage opportunity if found.
+
+    Args:
+        odds: list of normalized odds records.
+        threshold: sum of inverse odds must be below this number to be an arb.
+    """
+    if len(odds) < 2:
+        return None
+
+    # group by outcome
+    by_outcome: Dict[str, Dict[str, Any]] = {}
+    for item in odds:
+        out = item["outcome"]
+        if out not in by_outcome or item["odds"] > by_outcome[out]["odds"]:
+            by_outcome[out] = item
+
+    if len(by_outcome) != 2:
+        return None
+
+    outcomes = list(by_outcome.values())
+    inv_sum = sum(1 / o["odds"] for o in outcomes)
+    if inv_sum < threshold:
+        margin = 1 - inv_sum
+        return {"margin": margin, "legs": outcomes}
+    return None
+
+
+def scan_two_way_arbitrage(odds: List[Dict[str, Any]], threshold: float = 1.0) -> List[Dict[str, Any]]:
+    """Scan a list of normalized odds for arbitrage opportunities by event."""
+
+    events: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for record in odds:
+        events[record.get("event")].append(record)
+
+    results: List[Dict[str, Any]] = []
+    for event_id, records in events.items():
+        arb = find_two_way_arbitrage(records, threshold)
+        if arb:
+            arb["event"] = event_id
+            results.append(arb)
+
+    return results

--- a/bet_exchange_bot/execution.py
+++ b/bet_exchange_bot/execution.py
@@ -1,0 +1,8 @@
+from typing import Dict, Any
+
+
+async def place_bet(bookmaker: str, event: str, outcome: str, stake: float) -> Dict[str, Any]:
+    """Placeholder for automated bet placement."""
+    # In a real implementation this would control a headless browser or use an API.
+    print(f"Placing {stake} on {outcome} at {bookmaker} for event {event}")
+    return {"status": "submitted"}

--- a/bet_exchange_bot/ingestion.py
+++ b/bet_exchange_bot/ingestion.py
@@ -1,0 +1,31 @@
+import asyncio
+from typing import Any, Dict, List
+
+import aiohttp
+
+
+class SportsGameOddsIngestor:
+    """Fetch data from the Sports Game Odds API."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self.base_url = "https://api.sportsgameodds.com/v2"
+
+    async def fetch_sports(self) -> List[Dict[str, Any]]:
+        """Fetch the list of available sports."""
+        url = f"{self.base_url}/sports/"
+        headers = {"X-Api-Key": self.api_key}
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers, timeout=10) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+
+
+async def main() -> None:
+    ingestor = SportsGameOddsIngestor(api_key="YOUR_API_KEY")
+    data = await ingestor.fetch_sports()
+    print(data)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bet_exchange_bot/normalization.py
+++ b/bet_exchange_bot/normalization.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict, List
+
+
+def normalize_odds(raw: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert odds into decimal format and unify event identifiers."""
+    normalized = []
+    for event in raw:
+        for book in event.get("bookmakers", []):
+            for market in book.get("markets", []):
+                for outcome in market.get("outcomes", []):
+                    # convert American odds to decimal if necessary
+                    price = outcome.get("price")
+                    if price is None:
+                        continue
+                    if price >= 0:
+                        decimal = 1 + price / 100
+                    else:
+                        decimal = 1 - 100 / price
+                    normalized.append(
+                        {
+                            "event": event.get("id"),
+                            "bookmaker": book.get("title"),
+                            "outcome": outcome.get("name"),
+                            "odds": decimal,
+                        }
+                    )
+    return normalized

--- a/bet_exchange_bot/predictive.py
+++ b/bet_exchange_bot/predictive.py
@@ -1,0 +1,7 @@
+from typing import Dict, Any
+
+
+def naive_prediction(team_a: str, team_b: str) -> Dict[str, Any]:
+    """Return a naive probability estimate for team_a winning."""
+    # placeholder: 50/50 chance
+    return {"team_a": team_a, "team_b": team_b, "p_win_a": 0.5}

--- a/bet_exchange_bot/server.py
+++ b/bet_exchange_bot/server.py
@@ -1,0 +1,29 @@
+import asyncio
+from fastapi import FastAPI
+
+from .ingestion import SportsGameOddsIngestor
+from .normalization import normalize_odds
+from .arbitrage import scan_two_way_arbitrage
+
+app = FastAPI()
+
+
+@app.get("/ping")
+def ping() -> dict:
+    return {"status": "ok"}
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    # Example background task to fetch odds and search for an arbitrage
+    async def worker() -> None:
+        odds_data = []
+        ingestor = SportsGameOddsIngestor(api_key="YOUR_API_KEY")
+        raw = await ingestor.fetch_sports()
+        odds_data.extend(normalize_odds(raw))
+
+        arbs = scan_two_way_arbitrage(odds_data)
+        for arb in arbs:
+            print("Arbitrage found", arb)
+
+    asyncio.create_task(worker())

--- a/bet_exchange_bot/staking.py
+++ b/bet_exchange_bot/staking.py
@@ -1,0 +1,18 @@
+from typing import Tuple
+
+
+def kelly_stake(p: float, odds: float, bankroll: float, fraction: float = 0.5) -> float:
+    """Compute fractional Kelly stake."""
+    edge = p * (odds - 1) - (1 - p)
+    if edge <= 0:
+        return 0.0
+    stake = bankroll * (edge / (odds - 1)) * fraction
+    return max(stake, 0.0)
+
+
+def arbitrage_stakes(o1: float, o2: float, total: float) -> Tuple[float, float]:
+    """Split total stake between two outcomes to lock in profit."""
+    inv_sum = 1 / o1 + 1 / o2
+    s1 = total / (o1 * inv_sum)
+    s2 = total / (o2 * inv_sum)
+    return s1, s2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+aiohttp
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- remove previous ingestors and use `SportsGameOddsIngestor`
- update FastAPI server to fetch from Sports Game Odds
- clarify README with new data source

## Testing
- `python -m py_compile bet_exchange_bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683fb2805834832c8be56110a52e4f92